### PR TITLE
Hide nginx version

### DIFF
--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -32,6 +32,7 @@ http {
 
   sendfile        on;
   keepalive_timeout  65;
+  server_tokens off;
 
   # Monitoring
   server {


### PR DESCRIPTION
It's a big security flaw to let the version visible to all.
https://www.virendrachandak.com/techtalk/how-to-hide-nginx-version-number-in-headers-and-errors-pages/